### PR TITLE
fix: Add Scroll and zkSync chain adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ After EIP-4844, L2 transaction costs are driven by the L1 blob base fee — a vo
 - Optimism
 - Base
 - Scroll
+- zkSync Era
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "lint": "tsc --noEmit"
   },
-  "keywords": ["ethereum", "gas", "l2", "blob", "eip-4844", "arbitrum", "optimism", "base"],
+  "keywords": ["ethereum", "gas", "l2", "blob", "eip-4844", "arbitrum", "optimism", "base", "scroll", "zksync"],
   "author": "kcolbchain <krishna@kcolbchain.com>",
   "license": "MIT",
   "dependencies": {

--- a/src/chains/zksync.ts
+++ b/src/chains/zksync.ts
@@ -1,0 +1,14 @@
+import type { ChainAdapter } from '../types'
+
+/** zkSync Era: L2 cost = L2 execution fee + L1 data fee (post-EIP-4844 approximation) */
+export const zksync: ChainAdapter = {
+  name: 'zksync',
+  computeL2Cost(blobBaseFee: bigint, l2ExecutionFee: bigint): bigint {
+    // zkSync Era's L1 data fee is generally proportional to L1 base fee * data size.
+    // Approximating L1 data cost using blobBaseFee as a proxy for overall L1 data expense.
+    // A typical zkSync Era transaction might commit around 1000 bytes of data to L1.
+    const typicalDataUnits = 1000n
+    const l1Component = (blobBaseFee * typicalDataUnits) / 16n
+    return l2ExecutionFee + l1Component
+  },
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ program
 program
   .command('predict')
   .description('Predict gas costs N blocks ahead')
-  .requiredOption('--chain <chain>', 'Target chain: arbitrum, optimism, base, scroll')
+  .requiredOption('--chain <chain>', 'Target chain: arbitrum, optimism, base, scroll, zksync')
   .option('--blocks <n>', 'Blocks ahead to predict', '10')
   .option('--l1-rpc <url>', 'L1 Ethereum RPC URL', 'https://eth.llamarpc.com')
   .option('--l2-rpc <url>', 'L2 RPC URL')
@@ -25,6 +25,7 @@ program
       optimism: 'https://mainnet.optimism.io',
       base: 'https://mainnet.base.org',
       scroll: 'https://rpc.scroll.io',
+      zksync: 'https://mainnet.era.zksync.io',
     }
 
     const oracle = new GasOracle({

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -3,9 +3,10 @@ import { Predictor } from './predictor'
 import { arbitrum } from './chains/arbitrum'
 import { optimism, base } from './chains/optimism'
 import { scroll } from './chains/scroll'
+import { zksync } from './chains/zksync'
 import type { OracleConfig, Prediction, ChainAdapter, ChainName } from './types'
 
-const adapters: Record<ChainName, ChainAdapter> = { arbitrum, optimism, base, scroll }
+const adapters: Record<ChainName, ChainAdapter> = { arbitrum, optimism, base, scroll, zksync }
 
 export class GasOracle {
   private fetcher: FeeFetcher

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,29 +1,31 @@
-export type ChainName = 'arbitrum' | 'optimism' | 'base' | 'scroll'
+export type ChainName = 'arbitrum' | 'optimism' | 'base' | 'scroll' | 'zksync';
+
+export const VALID_CHAINS: ChainName[] = ['arbitrum', 'optimism', 'base', 'scroll', 'zksync'];
 
 export interface OracleConfig {
-  l1Rpc: string
-  l2Rpc: string
-  chain: ChainName
-  windowSize?: number // blocks of history to use (default 50)
+  l1Rpc: string;
+  l2Rpc: string;
+  chain: ChainName;
+  windowSize?: number; // blocks of history to use (default 50)
 }
 
 export interface FeeSnapshot {
-  blockNumber: bigint
-  blobBaseFee: bigint   // wei
-  l2GasPrice: bigint    // wei
-  timestamp: number
+  blockNumber: bigint;
+  blobBaseFee: bigint;   // wei
+  l2GasPrice: bigint;    // wei
+  timestamp: number;
 }
 
 export interface Prediction {
-  gasPrice: number      // gwei — predicted L2 gas price
-  blobFee: number       // gwei — predicted L1 blob base fee
-  confidence: number    // 0-1
-  blocksAhead: number
-  chain: ChainName
+  gasPrice: number;      // gwei — predicted L2 gas price
+  blobFee: number;       // gwei — predicted L1 blob base fee
+  confidence: number;    // 0-1
+  blocksAhead: number;
+  chain: ChainName;
 }
 
 export interface ChainAdapter {
-  name: ChainName
+  name: ChainName;
   /** Compute L2 gas price from L1 blob base fee and L2 execution fee */
-  computeL2Cost(blobBaseFee: bigint, l2ExecutionFee: bigint): bigint
+  computeL2Cost(blobBaseFee: bigint, l2ExecutionFee: bigint): bigint;
 }


### PR DESCRIPTION
Closes #6

## What changed
The Scroll adapter appears to be fully integrated already, so this fix focuses on adding the zkSync Era chain adapter and updating relevant configurations.

## Files modified
- `src/chains/zksync.ts`
- `src/types.ts`
- `src/oracle.ts`
- `src/cli.ts`
- `README.md`
- `package.json`

---
*Draft PR — please review before merging.*