### PR TITLE
Add Telegram alert for blob fee threshold

### DIFF
--- a/src/alerter.ts
+++ b/src/alerter.ts
@@ -9,3 +9,19 @@ export async function checkAndAlert(blobFee: number, threshold: number, chatId: 
     lastAlertTime = now;
   }
 }
+async function sendTelegram(chatId: string, fee: number) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+
+  await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text: `⚠️ Blob fee alert: ${fee} gwei exceeded threshold`
+    })
+  });
+}

--- a/src/alerter.ts
+++ b/src/alerter.ts
@@ -1,0 +1,11 @@
+let lastAlertTime = 0;
+
+export async function checkAndAlert(blobFee: number, threshold: number, chatId: string) {
+  const now = Date.now();
+
+  // Cooldown: 10 min
+  if (blobFee > threshold && now - lastAlertTime > 10 * 60 * 1000) {
+    await sendTelegram(chatId, blobFee);
+    lastAlertTime = now;
+  }
+}


### PR DESCRIPTION
This PR introduces a Telegram alert feature that notifies users when blob fees exceed a configurable threshold.

Changes:
Added new module alerter.ts
Implemented threshold-based alert logic
Integrated Telegram Bot API for notifications
Added cooldown mechanism (10 minutes)
Extended CLI with alert-related flags
Result:
Users can monitor blob fees automatically
Eliminates need for manual tracking
Useful for timing L2 transactions