### PR TITLE
docs: fix broken contributing guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ MIT
 
 ## Contributing
 
-Issues and PRs welcome. See the [kcolbchain contributing guide](https://github.com/kcolbchain).
+Issues and PRs welcome. See the [kcolbchain contributing guide](CONTRIBUTING.md).


### PR DESCRIPTION
### What
Change the "kcolbchain contributing guide" hyperlink in `README.md` from the GitHub org root (`https://github.com/kcolbchain`) to the actual `CONTRIBUTING.md` file in this repo.

### Why
The current link lands on the kcolbchain org homepage, not the contributing guide. Readers who click it get no useful information about how to contribute to this project.

Small, scoped fix from kcolbchain contrib-bot.