### PR TITLE
L2: Add Polygon zkEVM, Blast, and Mantle chain adapters

### DIFF
--- a/src/chains/blast.ts
+++ b/src/chains/blast.ts
@@ -1,0 +1,12 @@
+import type { ChainAdapter } from '../types'
+
+/** Blast: OP Stack rollup — Ecotone fee formula (same as Optimism) */
+export const blast: ChainAdapter = {
+  name: 'blast',
+  computeL2Cost(blobBaseFee: bigint, l2ExecutionFee: bigint): bigint {
+    const blobBaseFeeScalar = 810949n
+    const typicalTxSize = 200n
+    const l1Component = (blobBaseFeeScalar * blobBaseFee * typicalTxSize) / (16n * 1000000n)
+    return l2ExecutionFee + l1Component
+  },
+}

--- a/src/chains/mantle.ts
+++ b/src/chains/mantle.ts
@@ -1,0 +1,12 @@
+import type { ChainAdapter } from '../types'
+
+/** Mantle: OP Stack rollup — Ecotone fee formula (same as Optimism) */
+export const mantle: ChainAdapter = {
+  name: 'mantle',
+  computeL2Cost(blobBaseFee: bigint, l2ExecutionFee: bigint): bigint {
+    const blobBaseFeeScalar = 810949n
+    const typicalTxSize = 200n
+    const l1Component = (blobBaseFeeScalar * blobBaseFee * typicalTxSize) / (16n * 1000000n)
+    return l2ExecutionFee + l1Component
+  },
+}

--- a/src/chains/polygonzkevm.ts
+++ b/src/chains/polygonzkevm.ts
@@ -1,0 +1,12 @@
+import type { ChainAdapter } from '../types'
+
+/** Polygon zkEVM: L2 cost = execution fee + L1 pubdata cost (ZK-rollup similar to zkSync) */
+export const polygonzkevm: ChainAdapter = {
+  name: 'polygonzkevm',
+  computeL2Cost(blobBaseFee: bigint, l2ExecutionFee: bigint): bigint {
+    const gasPerPubdataByte = 16n
+    const typicalPubdataBytes = 256n
+    const l1Component = (blobBaseFee * typicalPubdataBytes) / gasPerPubdataByte
+    return l2ExecutionFee + l1Component
+  },
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,12 +18,15 @@ const l2RpcDefaults: Record<string, string> = {
   base: 'https://mainnet.base.org',
   scroll: 'https://rpc.scroll.io',
   zksync: 'https://mainnet.era.zksync.io',
+  polygonzkevm: 'https://zkevm-rpc.com',
+  blast: 'https://rpc.blast.io',
+  mantle: 'https://rpc.mantle.xyz',
 }
 
 program
   .command('predict')
   .description('Predict gas costs N blocks ahead')
-  .requiredOption('--chain <chain>', 'Target chain: arbitrum, optimism, base, scroll, zksync')
+  .requiredOption('--chain <chain>', 'Target chain: arbitrum, optimism, base, scroll, zksync, polygonzkevm, blast, mantle')
   .option('--blocks <n>', 'Blocks ahead to predict', '10')
   .option('--l1-rpc <url>', 'L1 Ethereum RPC URL', 'https://eth.llamarpc.com')
   .option('--l2-rpc <url>', 'L2 RPC URL')
@@ -54,7 +57,7 @@ program
 program
   .command('accuracy')
   .description('Compute historical prediction accuracy')
-  .requiredOption('--chain <chain>', 'Target chain: arbitrum, optimism, base, scroll, zksync')
+  .requiredOption('--chain <chain>', 'Target chain: arbitrum, optimism, base, scroll, zksync, polygonzkevm, blast, mantle')
   .requiredOption('--last <n>', 'Number of historical blocks to evaluate (e.g., 100)')
   .option('--blocks <n>', 'Blocks ahead the prediction was made for (N blocks later)', '10')
   .option('--l1-rpc <url>', 'L1 Ethereum RPC URL', 'https://eth.llamarpc.com')

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -4,9 +4,12 @@ import { arbitrum } from './chains/arbitrum'
 import { optimism, base } from './chains/optimism'
 import { scroll } from './chains/scroll'
 import { zksync } from './chains/zksync'
+import { polygonzkevm } from './chains/polygonzkevm'
+import { blast } from './chains/blast'
+import { mantle } from './chains/mantle'
 import type { OracleConfig, Prediction, ChainAdapter, ChainName } from './types'
 
-const adapters: Record<ChainName, ChainAdapter> = { arbitrum, optimism, base, scroll, zksync }
+const adapters: Record<ChainName, ChainAdapter> = { arbitrum, optimism, base, scroll, zksync, polygonzkevm, blast, mantle }
 
 export class GasOracle {
   private fetcher: FeeFetcher

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -4,9 +4,12 @@ import { arbitrum } from './chains/arbitrum';
 import { optimism, base } from './chains/optimism';
 import { scroll } from './chains/scroll';
 import { zksync } from './chains/zksync';
+import { polygonzkevm } from './chains/polygonzkevm';
+import { blast } from './chains/blast';
+import { mantle } from './chains/mantle';
 import type { ChainAdapter, ChainName, OracleConfig, Prediction, FeeSnapshot, AccuracyReport } from './types';
 
-const adapters: Record<ChainName, ChainAdapter> = { arbitrum, optimism, base, scroll, zksync };
+const adapters: Record<ChainName, ChainAdapter> = { arbitrum, optimism, base, scroll, zksync, polygonzkevm, blast, mantle };
 
 export class AccuracyTracker {
   private fetcher: FeeFetcher;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-export type ChainName = 'arbitrum' | 'optimism' | 'base' | 'scroll' | 'zksync';
+export type ChainName = 'arbitrum' | 'optimism' | 'base' | 'scroll' | 'zksync' | 'polygonzkevm' | 'blast' | 'mantle';
 
-export const VALID_CHAINS: ChainName[] = ['arbitrum', 'optimism', 'base', 'scroll', 'zksync'];
+export const VALID_CHAINS: ChainName[] = ['arbitrum', 'optimism', 'base', 'scroll', 'zksync', 'polygonzkevm', 'blast', 'mantle'];
 
 export interface OracleConfig {
   l1Rpc: string;

--- a/tests/chains/blast.test.ts
+++ b/tests/chains/blast.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { blast } from '../../src/chains/blast'
+
+describe('blast chain adapter', () => {
+  it('should have correct name', () => {
+    expect(blast.name).toBe('blast')
+  })
+
+  it('should compute L2 cost correctly', () => {
+    const blobBaseFee = 10000000000n
+    const l2ExecutionFee = 50000000n
+    const cost = blast.computeL2Cost(blobBaseFee, l2ExecutionFee)
+    expect(cost).toBe(101418625000n)
+  })
+
+  it('should handle zero blob base fee', () => {
+    const cost = blast.computeL2Cost(0n, 50000000n)
+    expect(cost).toBe(50000000n)
+  })
+
+  it('should handle zero execution fee', () => {
+    const cost = blast.computeL2Cost(10000000000n, 0n)
+    expect(cost).toBe(101368625000n)
+  })
+
+  it('should return bigint type', () => {
+    const result = blast.computeL2Cost(1n, 1n)
+    expect(typeof result).toBe('bigint')
+  })
+})

--- a/tests/chains/mantle.test.ts
+++ b/tests/chains/mantle.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { mantle } from '../../src/chains/mantle'
+
+describe('mantle chain adapter', () => {
+  it('should have correct name', () => {
+    expect(mantle.name).toBe('mantle')
+  })
+
+  it('should compute L2 cost correctly', () => {
+    const blobBaseFee = 10000000000n
+    const l2ExecutionFee = 50000000n
+    const cost = mantle.computeL2Cost(blobBaseFee, l2ExecutionFee)
+    expect(cost).toBe(101418625000n)
+  })
+
+  it('should handle zero blob base fee', () => {
+    const cost = mantle.computeL2Cost(0n, 50000000n)
+    expect(cost).toBe(50000000n)
+  })
+
+  it('should handle zero execution fee', () => {
+    const cost = mantle.computeL2Cost(10000000000n, 0n)
+    expect(cost).toBe(101368625000n)
+  })
+
+  it('should return bigint type', () => {
+    const result = mantle.computeL2Cost(1n, 1n)
+    expect(typeof result).toBe('bigint')
+  })
+})

--- a/tests/chains/polygonzkevm.test.ts
+++ b/tests/chains/polygonzkevm.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { polygonzkevm } from '../../src/chains/polygonzkevm'
+
+describe('polygonzkevm chain adapter', () => {
+  it('should have correct name', () => {
+    expect(polygonzkevm.name).toBe('polygonzkevm')
+  })
+
+  it('should compute L2 cost correctly', () => {
+    const blobBaseFee = 10000000000n
+    const l2ExecutionFee = 50000000n
+    const cost = polygonzkevm.computeL2Cost(blobBaseFee, l2ExecutionFee)
+    expect(cost).toBe(160050000000n)
+  })
+
+  it('should handle zero blob base fee', () => {
+    const cost = polygonzkevm.computeL2Cost(0n, 50000000n)
+    expect(cost).toBe(50000000n)
+  })
+
+  it('should handle zero execution fee', () => {
+    const cost = polygonzkevm.computeL2Cost(10000000000n, 0n)
+    expect(cost).toBe(160000000000n)
+  })
+
+  it('should return bigint type', () => {
+    const result = polygonzkevm.computeL2Cost(1n, 1n)
+    expect(typeof result).toBe('bigint')
+  })
+})


### PR DESCRIPTION
## Summary

Adds 3 new L2 chain adapters to the gas oracle, following the existing Scroll/zkSync adapter pattern.

### New Adapters
- **Polygon zkEVM** — ZK-rollup: L1 pubdata cost formula (blobBaseFee × pubdataBytes / gasPerPubdataByte)
- **Blast** — OP Stack rollup: Ecotone fee formula (same as Optimism)
- **Mantle** — OP Stack rollup: Ecotone fee formula (same as Optimism)

### Changes
| File | Change |
|------|--------|
| `src/chains/polygonzkevm.ts` | New adapter — Polygon zkEVM |
| `src/chains/blast.ts` | New adapter — Blast |
| `src/chains/mantle.ts` | New adapter — Mantle |
| `src/types.ts` | Added 3 chain names to ChainName + VALID_CHAINS |
| `src/oracle.ts` | Registered 3 adapters |
| `src/tracker.ts` | Registered 3 adapters |
| `src/cli.ts` | Added RPC defaults + CLI help text |
| `tests/chains/polygonzkevm.test.ts` | 5 adapter tests |
| `tests/chains/blast.test.ts` | 5 adapter tests |
| `tests/chains/mantle.test.ts` | 5 adapter tests |

### Testing
All 24 chain adapter tests pass (5 adapters × ~5 tests each).

Closes #23