### PR TITLE
fix(predictor): flat-trend R² should be 1 (perfect fit), and correct OLS test expectations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    name: vitest (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["20", "22"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gas-oracle
-[![repo](https://img.shields.io/badge/repo-gas-oracle-blue)](https://github.com/kcolbchain/gas-oracle)
+[![CI](https://github.com/kcolbchain/gas-oracle/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/gas-oracle/actions/workflows/ci.yml) [![repo](https://img.shields.io/badge/repo-gas--oracle-blue)](https://github.com/kcolbchain/gas-oracle)
 
 Predicts L2 gas costs 5-30 blocks ahead using blob fee market dynamics post-EIP-4844. By [kcolbchain](https://kcolbchain.com) (est. 2015).
 

--- a/src/predictor.ts
+++ b/src/predictor.ts
@@ -82,7 +82,9 @@ export class Predictor {
       ssTot += (values[i] - meanY) ** 2
       ssRes += (values[i] - (slope * i + intercept)) ** 2
     }
-    const r2 = ssTot === 0 ? 0 : 1 - ssRes / ssTot
+    // ssTot === 0 means all values equal meanY (flat series): the constant
+    // model is a perfect fit, so confidence is maximal.
+    const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot
 
     return { slope, intercept, r2 }
   }

--- a/tests/predictor.test.ts
+++ b/tests/predictor.test.ts
@@ -239,13 +239,13 @@ describe('Predictor', () => {
       const values = [1, 3, 2, 4, 3] // Scattered data
       const { slope, intercept, r2 } = predictor['linearRegression'](values)
 
-      // Expected values for this dataset (x=[0,1,2,3,4], y=[1,3,2,4,3]):
-      // Slope: 0.6
-      // Intercept: 1.6
-      // R2: 0.6
-      expect(slope).toBeCloseTo(0.6, 6)
+      // OLS for x=[0,1,2,3,4], y=[1,3,2,4,3]:
+      //   slope     = sum((x-x̄)(y-ȳ)) / sum((x-x̄)²) = 5.0 / 10 = 0.5
+      //   intercept = ȳ - slope * x̄                  = 2.6 - 0.5*2 = 1.6
+      //   r²        = 1 - ssRes/ssTot                 = 1 - 2.7/5.2 ≈ 0.481
+      expect(slope).toBeCloseTo(0.5, 6)
       expect(intercept).toBeCloseTo(1.6, 6)
-      expect(r2).toBeCloseTo(0.6, 6)
+      expect(r2).toBeCloseTo(0.4808, 3)
     })
 
     it('should handle single data point (n=1) case', () => {


### PR DESCRIPTION
## Summary

Two bugs found by running the suite — **3 of 38 vitest cases failing on main**:

### 1. Production bug in `predictor.ts`

`linearRegression` returned `r²=0` when `ssTot=0` (all values equal `meanY` → flat series). The constant model **perfectly** predicts a flat series, so `r²=1` by the textbook `1 − ssRes/ssTot` convention (here `ssRes=0` too — \"0/0\" case).

The current behaviour makes \`confidence\` collapse to ~0 for the **most predictable** input shape, which is the opposite of what the metric should say.

Fix:

\`\`\`diff
-    const r2 = ssTot === 0 ? 0 : 1 - ssRes / ssTot
+    // ssTot === 0 means all values equal meanY (flat series): the constant
+    // model is a perfect fit, so confidence is maximal.
+    const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot
\`\`\`

### 2. Test bug in `predictor.test.ts` (\"non-perfect fit\" case)

Test 3 used \`values = [1, 3, 2, 4, 3]\` and expected \`slope=0.6, intercept=1.6, r²=0.6\`. The actual textbook OLS for that dataset is **\`slope=0.5, intercept=1.6, r²≈0.481\`**. The test's expected \`slope\` and \`r²\` look like someone conflated the two (both 0.6).

Derivation written into the comment so the next reader can verify in 30 seconds:

\`\`\`
slope     = sum((x-x̄)(y-ȳ)) / sum((x-x̄)²) = 5.0 / 10        = 0.5
intercept = ȳ - slope·x̄                  = 2.6 - 0.5·2     = 1.6
r²        = 1 - ssRes/ssTot              = 1 - 2.7/5.2    ≈ 0.481
\`\`\`

## After both fixes

\`\`\`
Test Files  6 passed (6)
     Tests  38 passed (38)
\`\`\`

## Drive-by

CI workflow (vitest on Node 20/22) + badge + SECURITY.md.